### PR TITLE
Bump Microsoft STT form 1.0.0 to 1.0.1

### DIFF
--- a/microsoft-stt/build.yaml
+++ b/microsoft-stt/build.yaml
@@ -4,4 +4,4 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
 
 args:
-  MICROSOFT_STT_VERSION: 1.0.0
+  MICROSOFT_STT_VERSION: 1.0.1

--- a/microsoft-stt/config.yaml
+++ b/microsoft-stt/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Microsoft STT"
 description: "Speech to text using Microsoft Azure"
-version: "1.0.0"
+version: "1.0.1"
 slug: "wyoming_microsoft_stt"
 init: false
 arch:


### PR DESCRIPTION
This pull request updates the version of Microsoft STT from 1.0.0 to 1.0.1. This update includes bug fixes for #11 and updates packages.