### PR TITLE
Fix module import in Microsoft STT and TTS scripts

### DIFF
--- a/microsoft-stt/rootfs/etc/s6-overlay/s6-rc.d/microsoft/run
+++ b/microsoft-stt/rootfs/etc/s6-overlay/s6-rc.d/microsoft/run
@@ -12,7 +12,7 @@ if bashio::config.true 'debug_logging'; then
     flags+=('--debug')
 fi
 
-exec python3 -m wyoming_microsoft_stt \
+exec python3 -m wyoming-microsoft-stt \
     --uri "tcp://0.0.0.0:10300" \
     --subscription-key "$(bashio::config 'subscription_key')" \
     --service-region "$(bashio::config 'service_region')" \

--- a/microsoft-tts/rootfs/etc/s6-overlay/s6-rc.d/microsoft/run
+++ b/microsoft-tts/rootfs/etc/s6-overlay/s6-rc.d/microsoft/run
@@ -12,7 +12,7 @@ if bashio::config.true 'debug_logging'; then
     flags+=('--debug')
 fi
 
-exec python3 -m wyoming_microsoft_tts \
+exec python3 -m wyoming-microsoft-tts \
     --uri "tcp://0.0.0.0:10200" \
     --subscription-key "$(bashio::config 'subscription_key')" \
     --service-region "$(bashio::config 'service_region')" \


### PR DESCRIPTION
This pull request fixes the module import in the Microsoft STT and TTS scripts. The import statements have been updated to use hyphens instead of underscores. This ensures that the scripts can be executed correctly.