### PR TITLE
Add profanity filtering and update to version 1.2.0

### DIFF
--- a/microsoft-stt/CHANGELOG.md
+++ b/microsoft-stt/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.2.0](https://github.com/hugobloem/wyoming-microsoft-stt/compare/v1.1.0...v1.2.0) (2025-02-23)
+
+
+### 🚀 Features
+
+* add profanity filter ([35a8a25](https://github.com/hugobloem/wyoming-microsoft-stt/commit/35a8a251751bf8d0828c3ec9af74ef5dbb621f18))
+
+
+### 🔨 Code Refactoring
+
+* use Pydantic model for Microsoft STT configuration ([35a8a25](https://github.com/hugobloem/wyoming-microsoft-stt/commit/35a8a251751bf8d0828c3ec9af74ef5dbb621f18))
+
+
 ## [1.1.0](https://github.com/hugobloem/wyoming-microsoft-stt/compare/1.0.7...v1.1.0) (2024-11-20)
 
 Thanks to @carpenike for improving the secrets, logging, and making sure files are written to /tmp.

--- a/microsoft-stt/build.yaml
+++ b/microsoft-stt/build.yaml
@@ -4,4 +4,4 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
 
 args:
-  MICROSOFT_STT_VERSION: 1.1.0
+  MICROSOFT_STT_VERSION: 1.2.0

--- a/microsoft-stt/config.yaml
+++ b/microsoft-stt/config.yaml
@@ -19,5 +19,6 @@ schema:
   service_region: str
   debug_logging: bool
   update_voices: bool
+  profanity: list("off", "masked", "removed")
 tmpfs: true
 image: "ghcr.io/hugobloem/{arch}-wyoming-microsoft-stt"

--- a/microsoft-stt/config.yaml
+++ b/microsoft-stt/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Microsoft STT"
 description: "Speech to text using Microsoft Azure"
-version: "1.1.0"
+version: "1.2.0"
 slug: "wyoming_microsoft_stt"
 init: false
 arch:

--- a/microsoft-stt/rootfs/etc/s6-overlay/s6-rc.d/microsoft/run
+++ b/microsoft-stt/rootfs/etc/s6-overlay/s6-rc.d/microsoft/run
@@ -17,4 +17,5 @@ exec python3 -m wyoming_microsoft_stt \
     --subscription-key "$(bashio::config 'subscription_key')" \
     --service-region "$(bashio::config 'service_region')" \
     --download-dir /data \
+    --profanity "$(bashio::config 'profanity')" \
     ${flags[@]}

--- a/microsoft-stt/translations/en.yaml
+++ b/microsoft-stt/translations/en.yaml
@@ -14,6 +14,12 @@ configuration:
       Download the list of new languages automatically every time the add-on
       starts.  You must also reload the Wyoming integration for Microsoft in Home
       Assistant to see new languages.
+  profanity:
+    name: Profanity
+    description: >-
+      The level of profanity filtering to apply to the speech recognition. Off
+      means no filtering, Masked means the profanity is replaced with asterisks,
+      and Removed means the profanity is removed from the text.
   debug_logging:
     name: Debug logging
     description: >-

--- a/microsoft-stt/translations/fr.yaml
+++ b/microsoft-stt/translations/fr.yaml
@@ -12,6 +12,10 @@ configuration:
     name: Mettre à jour les langues
     description: >-
       Téléchargez automatiquement la liste des nouvelles langues à chaque démarrage de l'add-on. Vous devez également recharger l'intégration Wyoming pour Microsoft dans Home Assistant pour voir les nouvelles langues.
+  profanity:
+    name: Profanité
+    description: >-
+      Le niveau de filtrage de la profanité à appliquer à la reconnaissance vocale. Off signifie aucun filtrage, Masked signifie que la profanité est remplacée par des astérisques, et Removed signifie que la profanité est supprimée du texte.
   debug_logging:
     name: Journalisation de débogage
     description: >-

--- a/microsoft-stt/translations/nl.yaml
+++ b/microsoft-stt/translations/nl.yaml
@@ -14,6 +14,12 @@ configuration:
       Download de lijst met nieuwe talen automatisch elke keer dat de add-on
       start. U moet ook de Wyoming-integratie voor Microsoft in Home
       Assistant opnieuw laden om nieuwe talen te zien.
+  profanity:
+    name: Vloeken
+    description: >-
+      Het niveau van vloekfiltering dat moet worden toegepast op de spraakherkenning. Off
+      betekent geen filtering, Masked betekent dat de vloek wordt vervangen door asterisken,
+      en Removed betekent dat de vloek uit de tekst wordt verwijderd.
   debug_logging:
     name: Debug logging
     description: >-


### PR DESCRIPTION
Introduce profanity filtering configuration with translations and update the Microsoft STT version to 1.2.0. Update the CHANGELOG to reflect these changes.