### PR TITLE
Get options from flags in script execution

### DIFF
--- a/microsoft-stt/rootfs/etc/s6-overlay/s6-rc.d/microsoft/run
+++ b/microsoft-stt/rootfs/etc/s6-overlay/s6-rc.d/microsoft/run
@@ -17,5 +17,4 @@ exec python3 -m wyoming_microsoft_stt \
     --subscription-key "$(bashio::config 'subscription_key')" \
     --service-region "$(bashio::config 'service_region')" \
     --download-dir /data \
-    --profanity "$(bashio::config 'profanity')" \
     ${flags[@]}


### PR DESCRIPTION
Remove the hardcoded profanity option and retrieve it from flags instead. This change enhances flexibility in configuring the script.