### PR TITLE
Bump Microsoft TTS to version 1.3.1

### DIFF
--- a/microsoft-tts/CHANGELOG.md
+++ b/microsoft-tts/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.3.1](https://github.com/hugobloem/wyoming-microsoft-tts/compare/v1.3.0...v1.3.1) (2025-08-21)
+
+
+### 🐛 Bugfixes
+
+* voice parsing errors for locales with script codes (fixes [#111](https://github.com/hugobloem/wyoming-microsoft-tts/issues/111)) ([#120](https://github.com/hugobloem/wyoming-microsoft-tts/issues/120)) ([b2f02fb](https://github.com/hugobloem/wyoming-microsoft-tts/commit/b2f02fbab62d608d7154375e754f9ec63215d661))
+
+
+### 🧪 Tests
+
+* Add comprehensive test coverage for voices.json download functionality ([#121](https://github.com/hugobloem/wyoming-microsoft-tts/issues/121)) ([ba0271d](https://github.com/hugobloem/wyoming-microsoft-tts/commit/ba0271d1bf511d9afc0343566708c1bf79ab4c56))
+
+
+### 🏗️ Maintenance
+
+* **deps:** bump actions/checkout from 4 to 5 ([#118](https://github.com/hugobloem/wyoming-microsoft-tts/issues/118)) ([31deb21](https://github.com/hugobloem/wyoming-microsoft-tts/commit/31deb214e73ba2c3a46a5870debd1117c7492059))
+
 ## [1.3.0](https://github.com/hugobloem/wyoming-microsoft-tts/compare/v1.2.1...v1.3.0) (2025-08-07)
 
 

--- a/microsoft-tts/build.yaml
+++ b/microsoft-tts/build.yaml
@@ -3,4 +3,4 @@ build_from:
   amd64: ghcr.io/home-assistant/amd64-base-debian:bullseye
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bullseye
 args:
-  MICROSOFT_TTS_VERSION: 1.3.0
+  MICROSOFT_TTS_VERSION: 1.3.1

--- a/microsoft-tts/config.yaml
+++ b/microsoft-tts/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Microsoft TTS"
 description: "Text to speech using Microsoft Azure"
-version: "1.3.0"
+version: "1.3.1"
 slug: "wyoming_microsoft_tts"
 init: false
 arch:


### PR DESCRIPTION
This pull request updates the Microsoft TTS integration to version 1.3.1, addressing a locale parsing bug and improving test coverage and maintenance. The most important changes are grouped below:

Bugfixes:

* Fixed voice parsing errors for locales with script codes, resolving issue #111.

Testing improvements:

* Added comprehensive test coverage for the `voices.json` download functionality.

Maintenance and versioning:

* Updated the `MICROSOFT_TTS_VERSION` in `build.yaml` to 1.3.1.
* Updated the `version` field in `config.yaml` to 1.3.1.
* Bumped `actions/checkout` from version 4 to 5 for CI maintenance.