### PR TITLE
fix: remove outdated options from config

### DIFF
--- a/microsoft-stt/rootfs/etc/s6-overlay/s6-rc.d/microsoft/run
+++ b/microsoft-stt/rootfs/etc/s6-overlay/s6-rc.d/microsoft/run
@@ -5,6 +5,11 @@
 # ==============================================================================
 flags=("--profanity $(bashio::config 'profanity')")
 
+# Remove outdated options
+if bashio::config.exists 'update_voices'
+    bashio::addon.option 'update_voices'
+fi
+
 if bashio::config.true 'update_languages'; then
     flags+=('--update-languages')
 fi


### PR DESCRIPTION
Removed outdated options handling from Microsoft service script.

Fixes: https://github.com/hugobloem/wyoming-microsoft-stt/issues/100