### PR TITLE
chore: change workflows to dev

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -7,10 +7,11 @@ env:
 on:
   push:
     branches:
-      - main
+      - dev
   pull_request:
     branches:
       - main
+      - dev
 
 jobs:
   init:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     branches:
       - main
+      - dev
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/update_version.yaml
+++ b/.github/workflows/update_version.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   push:
    branches:
-    - main
+    - dev
 
 jobs:
   init:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to run on the `dev` branch in addition to (or instead of) the `main` branch. This ensures that CI/CD processes such as building, linting, and version updates are triggered for changes pushed to or pull requests targeting the `dev` branch.

**Workflow trigger updates:**

* [`.github/workflows/builder.yaml`](diffhunk://#diff-c5fb9d7d821ca8e489c7a19d9761fd13a6e47ad5a201b20838f2f9364096b5eeL10-R14): Changed workflow triggers so that both push and pull request events now include the `dev` branch alongside `main`.
* [`.github/workflows/lint.yaml`](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bR7-R11): Updated workflow triggers to run on pushes and pull requests to the `dev` branch, in addition to `main`.
* [`.github/workflows/update_version.yaml`](diffhunk://#diff-79fcf7a82371b3a0836667d6d0d8aed3f0190696c3071f525f03e753775e4601L10-R10): Modified workflow triggers so that pushes to the `dev` branch now initiate the workflow instead of only `main`.